### PR TITLE
Fix for setting endTime

### DIFF
--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/TimeRangePicker.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/TimeRangePicker.kt
@@ -680,7 +680,7 @@ class TimeRangePicker @JvmOverloads constructor(
             endTimeMinutes
         )
         set(value) {
-            _angleStart = minutesToAngle(value.totalMinutes, _hourFormat)
+            _angleEnd = minutesToAngle(value.totalMinutes, _hourFormat)
             postInvalidate()
         }
 


### PR DESCRIPTION
While using the library, I have encountered an issue with setting end time from Kotlin code. When updating endTime, the start angle is updated instead of the end angle. This PR fixes the issue.