### PR TITLE
Don't compute sin, cos twice for the same angle

### DIFF
--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/ClockRenderer.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/ClockRenderer.kt
@@ -59,15 +59,16 @@ internal class ClockRenderer(private val timeRangePicker: TimeRangePicker) {
 
         for (i in 0 until tickCount) {
             val angle = anglePerTick * i
+            val angleRadians = Math.toRadians(angle.toDouble())
 
-            getPositionByAngle(radius, angle, drawTicksPosition)
-            val startX = drawTicksPosition.x
-            val startY = drawTicksPosition.y
+            val sinAngle = sin(angleRadians).toFloat()
+            val cosAngle = cos(angleRadians).toFloat()
 
-            getPositionByAngle(radius - tickLength, angle, drawTicksPosition)
+            val startX = _middle.x + radius * cosAngle
+            val startY = _middle.y + radius * sinAngle
 
-            val stopX = drawTicksPosition.x
-            val stopY = drawTicksPosition.y
+            val stopX = _middle.x + (radius - tickLength) * cosAngle
+            val stopY = _middle.y + (radius - tickLength) * sinAngle
 
             if (timeRangePicker.clockFace == TimeRangePicker.ClockFace.SAMSUNG &&
                 ((angle >= 90-offset && angle <= 90+offset) ||

--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/ClockRenderer.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/ClockRenderer.kt
@@ -47,8 +47,6 @@ internal class ClockRenderer(private val timeRangePicker: TimeRangePicker) {
         drawLabels(canvas, radius)
     }
 
-    private val drawTicksPosition = PointF()
-
     private fun drawTicks(canvas: Canvas, radius: Float) {
         val hourTickInterval = if(timeRangePicker.hourFormat == TimeRangePicker.HourFormat.FORMAT_24) 24 else 12
         val tickLength = _tickLength
@@ -60,6 +58,7 @@ internal class ClockRenderer(private val timeRangePicker: TimeRangePicker) {
         for (i in 0 until tickCount) {
             val angle = anglePerTick * i
             val angleRadians = Math.toRadians(angle.toDouble())
+            val stopRadius = radius - tickLength
 
             val sinAngle = sin(angleRadians).toFloat()
             val cosAngle = cos(angleRadians).toFloat()
@@ -67,8 +66,8 @@ internal class ClockRenderer(private val timeRangePicker: TimeRangePicker) {
             val startX = _middle.x + radius * cosAngle
             val startY = _middle.y + radius * sinAngle
 
-            val stopX = _middle.x + (radius - tickLength) * cosAngle
-            val stopY = _middle.y + (radius - tickLength) * sinAngle
+            val stopX = _middle.x + stopRadius * cosAngle
+            val stopY = _middle.y + stopRadius * sinAngle
 
             if (timeRangePicker.clockFace == TimeRangePicker.ClockFace.SAMSUNG &&
                 ((angle >= 90-offset && angle <= 90+offset) ||

--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/utils/MathUtils.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/utils/MathUtils.kt
@@ -4,16 +4,22 @@ import nl.joery.timerangepicker.TimeRangePicker
 import kotlin.math.*
 
 internal object MathUtils {
+    private const val R2D = 180f / PI.toFloat()
+
     fun differenceBetweenAngles(a1: Float, a2: Float): Float {
         val angle1 = Math.toRadians(a1.toDouble())
         val angle2 = Math.toRadians(a2.toDouble())
 
-        return Math.toDegrees(
-            atan2(
-                cos(angle1) * sin(angle2) - sin(angle1) * cos(angle2),
-                cos(angle1) * cos(angle2) + sin(angle1) * sin(angle2)
-            )
-        ).toFloat()
+        val sinAngle1 = sin(angle1).toFloat()
+        val cosAngle1 = cos(angle1).toFloat()
+
+        val sinAngle2 = sin(angle2).toFloat()
+        val cosAngle2 = cos(angle2).toFloat()
+
+        return atan2(
+                cosAngle1 * sinAngle2 - sinAngle1 * cosAngle2,
+                cosAngle1 * cosAngle2 + sinAngle1 * sinAngle2
+        ) * R2D
     }
 
     fun angleTo360(angle: Float): Float {


### PR DESCRIPTION
There are few cases in code where exprensive functions are called twice for the same angle. Newer runtimes are able to optimize such cases and speed of my version and current one will be the same. But older runtimes cannot do that.
### Benchmarks:

In `drawTicks` ([Benchmark](https://github.com/pelmenstar1/TimeRangePicker/blob/benchmarks/benchmark/src/androidTest/java/com/pelmenstar/benchmark/ComputeLineCoordBenchmark.kt)):

- Fly FS504 (API 21):
current - **1 655** ns
new - **677** ns
-  ZTE Blade V9 (API 27)
current - **426** ns
new - **198** ns

In `differenceBetweenAngles` ([Benchmark](https://github.com/pelmenstar1/TimeRangePicker/blob/benchmarks/benchmark/src/androidTest/java/com/pelmenstar/benchmark/DiffBetweenAnglesBenchmark.kt)):

- Fly FS504 (API 21):
current - **2 982** ns
new - **1 830** ns
- ZTE Blade V9 (API 27):
current - **436** ns
new - **425** ns

As you can see, newer runtime optimized `differenceBetweenAngles` and speed is almost the same