### PR TITLE
Don't use nullable types on primitive to avoid tons of (un)boxing

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -30,17 +30,17 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.5.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     implementation project(path: ':timerangepicker')
 
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'com.google.android.material:material:1.4.0'
     implementation 'com.jaredrummler:colorpicker:1.1.0'
     implementation 'nl.joery.animatedbottombar:library:1.1.0'
 }

--- a/demo/src/main/java/nl/joery/demo/timerangepicker/ExampleActivity.kt
+++ b/demo/src/main/java/nl/joery/demo/timerangepicker/ExampleActivity.kt
@@ -121,7 +121,7 @@ class ExampleActivity : AppCompatActivity() {
                 picker.sliderColor = Color.TRANSPARENT
                 picker.thumbColor = Color.WHITE
                 picker.sliderRangeGradientStart = Color.parseColor("#F79104")
-                picker.sliderRangeGradientMiddle = null
+                picker.sliderRangeGradientMiddle = TimeRangePicker.COLOR_NONE
                 picker.sliderRangeGradientEnd = Color.parseColor("#F8C207")
                 picker.thumbIconColor = Color.parseColor("#F79104")
                 picker.thumbSizeActiveGrow = 1.0f
@@ -135,7 +135,7 @@ class ExampleActivity : AppCompatActivity() {
                 picker.thumbColor = Color.TRANSPARENT
                 picker.thumbIconColor = Color.WHITE
                 picker.sliderRangeGradientStart = Color.parseColor("#5663de")
-                picker.sliderRangeGradientMiddle = null
+                picker.sliderRangeGradientMiddle = TimeRangePicker.COLOR_NONE
                 picker.sliderRangeGradientEnd = Color.parseColor("#6d7bff")
                 picker.thumbSizeActiveGrow = 1.0f
                 picker.clockFace = TimeRangePicker.ClockFace.SAMSUNG

--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/TimeRangePicker.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/TimeRangePicker.kt
@@ -934,11 +934,11 @@ class TimeRangePicker @JvmOverloads constructor(
             sliderRangeColor = ContextCompat.getColor(context, value)
         }
 
-    var sliderRangeGradientStart: Int?
+    var sliderRangeGradientStart: Int
         @ColorInt
-        get() = _sliderRangeGradientStart.nullIfNone()
+        get() = _sliderRangeGradientStart
         set(@ColorInt value) {
-            _sliderRangeGradientStart = value ?: COLOR_NONE
+            _sliderRangeGradientStart = value
             updatePaint()
         }
 
@@ -949,11 +949,11 @@ class TimeRangePicker @JvmOverloads constructor(
             sliderRangeGradientStart = ContextCompat.getColor(context, value)
         }
 
-    var sliderRangeGradientMiddle: Int?
+    var sliderRangeGradientMiddle: Int
         @ColorInt
-        get() = _sliderRangeGradientMiddle.nullIfNone()
+        get() = _sliderRangeGradientMiddle
         set(@ColorInt value) {
-            _sliderRangeGradientMiddle = value ?: COLOR_NONE
+            _sliderRangeGradientMiddle = value
             updatePaint()
         }
 
@@ -964,11 +964,11 @@ class TimeRangePicker @JvmOverloads constructor(
             sliderRangeGradientMiddle = ContextCompat.getColor(context, value)
         }
 
-    var sliderRangeGradientEnd: Int?
+    var sliderRangeGradientEnd: Int
         @ColorInt
-        get() = _sliderRangeGradientEnd.nullIfNone()
+        get() = _sliderRangeGradientEnd
         set(@ColorInt value) {
-            _sliderRangeGradientEnd = value ?: COLOR_NONE
+            _sliderRangeGradientEnd = value
             updatePaint()
         }
 
@@ -995,11 +995,11 @@ class TimeRangePicker @JvmOverloads constructor(
             computeClockRadius()
         }
 
-    var thumbColor: Int?
+    var thumbColor: Int
         @ColorInt
-        get() = _thumbColor.nullIfNone()
+        get() = _thumbColor
         set(@ColorInt value) {
-            _thumbColor = value ?: COLOR_NONE
+            _thumbColor = value
             _thumbColorAuto = false
             updatePaint()
         }
@@ -1046,18 +1046,18 @@ class TimeRangePicker @JvmOverloads constructor(
             thumbIconEnd = ContextCompat.getDrawable(context, value)
         }
 
-    var thumbIconSize: Int?
-        get() = if(_thumbIconSize == -1) null else _thumbIconSize
+    var thumbIconSize: Int
+        get() = _thumbIconSize
         set(value) {
-            _thumbIconSize = value ?: -1
+            _thumbIconSize = value
             invalidate()
         }
 
-    var thumbIconColor: Int?
+    var thumbIconColor: Int
         @ColorInt
-        get() = _thumbIconColor.nullIfNone()
+        get() = _thumbIconColor
         set(@ColorInt value) {
-            _thumbIconColor = value ?: COLOR_NONE
+            _thumbIconColor = value
             updateThumbIconColors()
         }
 
@@ -1124,9 +1124,6 @@ class TimeRangePicker @JvmOverloads constructor(
             invalidateBitmapCache()
             invalidate()
         }
-
-    @ColorInt
-    private fun Int.nullIfNone(): Int? = if(this == COLOR_NONE) null else this
 
     companion object {
         private const val COLOR_NONE: Int = 0x00c0ffee

--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/TimeRangePicker.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/TimeRangePicker.kt
@@ -1124,7 +1124,7 @@ class TimeRangePicker @JvmOverloads constructor(
         }
 
     companion object {
-        private const val COLOR_NONE: Int = 0x00c0ffee
+        const val COLOR_NONE: Int = 0x00c0ffee
     }
 
     open class Time(val totalMinutes: Int) {


### PR DESCRIPTION
Type Int? in Kotlin JVM maps to reference type Integer. It causes memory allocations. In our case, nullability isn't necessary and can be avoided.

To save compatibility with the last version of the library, some variables types are explicitly marked.

_Maybe we should break compatibility and then, boxed types won't be used at all._