### PR TITLE
Fix #8

### DIFF
--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/TimeRangePicker.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/TimeRangePicker.kt
@@ -137,12 +137,13 @@ class TimeRangePicker @JvmOverloads constructor(
             context.obtainStyledAttributes(attributeSet, R.styleable.TimeRangePicker, 0, 0)
         try {
             // Time
+            // Sets public property to determine 24 / 12 format automatically
             hourFormat = HourFormat.fromId(
                 attr.getInt(
                     R.styleable.TimeRangePicker_trp_hourFormat,
                     _hourFormat.id
                 )
-            ) ?: _hourFormat // Sets public property to determine 24 / 12 format automatically
+            )
             _angleStart = minutesToAngle(
                 attr.getInt(
                     R.styleable.TimeRangePicker_trp_endTimeMinutes,
@@ -237,7 +238,7 @@ class TimeRangePicker @JvmOverloads constructor(
                     R.styleable.TimeRangePicker_trp_clockFace,
                     _clockFace.id
                 )
-            ) ?: _clockFace
+            )
 
             _clockLabelSize = attr.getDimensionPixelSize(
                 R.styleable.TimeRangePicker_trp_clockLabelSize,
@@ -1172,7 +1173,7 @@ class TimeRangePicker @JvmOverloads constructor(
         FORMAT_24(2);
 
         companion object {
-            fun fromId(id: Int): HourFormat? {
+            fun fromId(id: Int): HourFormat {
                 for (f in values()) {
                     if (f.id == id) return f
                 }
@@ -1186,7 +1187,7 @@ class TimeRangePicker @JvmOverloads constructor(
         SAMSUNG(1);
 
         companion object {
-            fun fromId(id: Int): ClockFace? {
+            fun fromId(id: Int): ClockFace {
                 for (f in values()) {
                     if (f.id == id) return f
                 }


### PR DESCRIPTION
As @Droppers said, when to _fromId()_ methods invalid id is passed, it should throws exception with no message, despite of nullable return type. Return type is set to non-nullable because it never returns null.