### PR TITLE
Use more clear names for methods changing unit of value.

### DIFF
--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/DefaultClockRenderer.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/DefaultClockRenderer.kt
@@ -2,8 +2,8 @@ package nl.joery.timerangepicker
 
 import android.graphics.*
 import androidx.annotation.Keep
-import nl.joery.timerangepicker.utils.dp
-import nl.joery.timerangepicker.utils.px
+import nl.joery.timerangepicker.utils.dpToPx
+import nl.joery.timerangepicker.utils.pxToDp
 import kotlin.math.cos
 import kotlin.math.sin
 
@@ -15,14 +15,17 @@ object DefaultClockRenderer: ClockRenderer {
     private val LABELS_SAMSUNG_24 = arrayOf("0", "6", "12", "18")
     private val LABELS_SAMSUNG_12 = arrayOf("12", "3", "6", "9")
 
-    private val _minuteTickWidth = 1.px
-    private val _hourTickWidth = 2.px
+    private val _minuteTickWidth = dpToPx(1f)
+    private val _hourTickWidth = dpToPx(2f)
     private val _middle = PointF(0f, 0f)
 
-    private val TimeRangePicker._tickLength
-        get() = when (clockFace) {
-            TimeRangePicker.ClockFace.APPLE -> 6.px
-            TimeRangePicker.ClockFace.SAMSUNG -> 4.px
+    private val TimeRangePicker._tickLength: Float
+        get() {
+            val dp = when(clockFace) {
+                TimeRangePicker.ClockFace.APPLE -> 6f
+                TimeRangePicker.ClockFace.SAMSUNG -> 4f
+            }
+            return dpToPx(dp)
         }
 
     private val TimeRangePicker._tickCount: Int
@@ -58,7 +61,7 @@ object DefaultClockRenderer: ClockRenderer {
         val tickLength = picker._tickLength
         val tickCount = picker._tickCount
         val hourTick = tickCount / hourTickInterval
-        val offset = if(picker.clockLabelSize.dp <= 16) 3 else 6
+        val offset = if(pxToDp(picker.clockLabelSize.toFloat()) <= 16) 3 else 6
         val anglePerTick = 360f / tickCount
 
         for (i in 0 until tickCount) {
@@ -87,10 +90,10 @@ object DefaultClockRenderer: ClockRenderer {
             // Hour tick
             if (i % hourTick == 0) {
                 _tickPaint.alpha = 180
-                _tickPaint.strokeWidth = _hourTickWidth.toFloat()
+                _tickPaint.strokeWidth = _hourTickWidth
             } else {
                 _tickPaint.alpha = 100
-                _tickPaint.strokeWidth = _minuteTickWidth.toFloat()
+                _tickPaint.strokeWidth = _minuteTickWidth
             }
             canvas.drawLine(startX, startY, stopX, stopY, _tickPaint)
         }
@@ -119,7 +122,7 @@ object DefaultClockRenderer: ClockRenderer {
 
         val bounds = _drawLabelsBounds
         val position = _drawLabelsPosition
-        val tickLength = picker._tickLength.toFloat()
+        val tickLength = picker._tickLength
 
         for (i in labels.indices) {
             val label = labels[i]

--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/TimeRangePicker.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/TimeRangePicker.kt
@@ -45,14 +45,14 @@ class TimeRangePicker @JvmOverloads constructor(
     private val _sliderRect: RectF = RectF()
     private val _sliderCapRect: RectF = RectF()
 
-    private var _sliderWidth: Int = 8.px
+    private var _sliderWidth: Int = dpToPx(8f).toInt()
     private var _sliderColor by Delegates.notNull<Int>()
     private var _sliderRangeColor by Delegates.notNull<Int>()
     private var _sliderRangeGradientStart: Int? = null
     private var _sliderRangeGradientMiddle: Int? = null
     private var _sliderRangeGradientEnd: Int? = null
 
-    private var _thumbSize: Int = 28.px
+    private var _thumbSize: Int = dpToPx(28f).toInt()
     private var _thumbSizeActiveGrow: Float = 1.2f
     private var _thumbIconStart: Drawable? = null
     private var _thumbIconEnd: Drawable? = null
@@ -63,7 +63,7 @@ class TimeRangePicker @JvmOverloads constructor(
 
     private var _clockVisible: Boolean = true
     private var _clockFace: ClockFace = ClockFace.APPLE
-    private var _clockLabelSize = 15.sp
+    private var _clockLabelSize = spToPx(15f).toInt()
     private var _clockLabelColor by Delegates.notNull<Int>()
     private var _clockTickColor by Delegates.notNull<Int>()
 
@@ -404,7 +404,7 @@ class TimeRangePicker @JvmOverloads constructor(
         super.onDraw(canvas)
 
         if (_clockVisible) {
-            val radius = _radius - max(_thumbSize, _sliderWidth) / 2f - 8.px
+            val radius = _radius - max(_thumbSize, _sliderWidth) / 2f - dpToPx(8f)
             _clockRenderer.render(canvas, this, radius)
         }
 
@@ -533,7 +533,7 @@ class TimeRangePicker @JvmOverloads constructor(
 
         if (icon != null) {
             val iconSize =
-                _thumbIconSize?.toFloat() ?: min(24.px.toFloat(), _thumbSize * 0.625f)
+                _thumbIconSize?.toFloat() ?: min(dpToPx(24f), _thumbSize * 0.625f)
             icon.setBounds(
                 (x - iconSize / 2).toInt(),
                 (y - iconSize / 2).toInt(),

--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/utils/Extensions.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/utils/Extensions.kt
@@ -7,6 +7,15 @@ import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
 
+private val displayMetrics = Resources.getSystem().displayMetrics
+private val density = displayMetrics.density
+private val invDensity = 1f / density
+private val sDensity = displayMetrics.scaledDensity
+
+fun dpToPx(value: Float): Float = value * density
+fun pxToDp(value: Float): Float = value * invDensity
+fun spToPx(value: Float): Float = value * sDensity
+
 @ColorInt
 internal fun Context.getColorResCompat(@AttrRes id: Int): Int {
     return ContextCompat.getColor(this, getResourceId(id))
@@ -31,16 +40,3 @@ internal fun Context.getResourceId(id: Int): Int {
     theme.resolveAttribute(id, resolvedAttr, true)
     return resolvedAttr.run { if (resourceId != 0) resourceId else data }
 }
-
-internal val Int.px: Int
-    get() = (this * Resources.getSystem().displayMetrics.density).toInt()
-
-internal val Int.dp: Int
-    get() = (this / Resources.getSystem().displayMetrics.density).toInt()
-
-internal val Int.sp: Int
-    get() = TypedValue.applyDimension(
-        TypedValue.COMPLEX_UNIT_SP,
-        this.toFloat(),
-        Resources.getSystem().displayMetrics
-    ).toInt()


### PR DESCRIPTION
For example expression _2.px_ tells nothing about from what to what unit we convert. It's better to use _dpToPx_ name. This name tells us that we convert from dp to pixels. Everything is clear.
Int.dp **->** pxToDp(Float): Float
Int.sp **->** spToPx(Float): Float

And argument and return type are changed to _Float_, because more often we use _Float_, not _Int_