### PR TITLE
Clock bitmap cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,18 +283,9 @@ The attributes listed below can be used to configure the look and feel of the pi
             <br/> 
             Note that, you should add <b>@Keep</b> annotation to your custom renderer class.
             <br/>
-            There are some requirements which should be met.
-            <br/>
-            The renderer class should have a public constructor with no parameters.
+            The renderer class should have a public constructor with one parameter: TimeRangePicker.
             <br/>
             Then renderer will be created through calling that constructor.
-            <br/>
-            Or the class should have non-null <b>public static final INSTANCE</b> field. 
-            <br/>
-            The value of the field should extend <b>ClockRenderer</b> 
-            <br/>
-            If the class contains both public constructor and <b>INSTANCE</b> field,
-            the way through calling constructor is preferred
         </td>
         <td>nl.joery.timerangepicker.DefaultClockRenderer</td>
     </tr>

--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/BitmapCachedClockRenderer.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/BitmapCachedClockRenderer.kt
@@ -1,0 +1,8 @@
+package nl.joery.timerangepicker
+
+interface BitmapCachedClockRenderer: ClockRenderer {
+    var isBitmapCacheEnabled: Boolean
+
+    fun invalidateBitmapCache()
+    fun recycleBitmapCache()
+}

--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/ClockRenderer.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/ClockRenderer.kt
@@ -3,5 +3,5 @@ package nl.joery.timerangepicker
 import android.graphics.Canvas
 
 interface ClockRenderer {
-    fun render(canvas: Canvas, picker: TimeRangePicker, radius: Float)
+    fun render(canvas: Canvas)
 }

--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/DefaultClockRenderer.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/DefaultClockRenderer.kt
@@ -1,32 +1,43 @@
 package nl.joery.timerangepicker
 
 import android.graphics.*
+import android.os.Build
 import androidx.annotation.Keep
+import androidx.annotation.RequiresApi
 import nl.joery.timerangepicker.utils.dp
 import nl.joery.timerangepicker.utils.px
 import kotlin.math.cos
 import kotlin.math.sin
 
 @Keep
-object DefaultClockRenderer: ClockRenderer {
-    private val LABELS_APPLE_24 = arrayOf("0", "2", "4", "6", "8", "10", "12", "14", "16", "18", "20", "22")
-    private val LABELS_APPLE_12 =  arrayOf("12", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11")
-
-    private val LABELS_SAMSUNG_24 = arrayOf("0", "6", "12", "18")
-    private val LABELS_SAMSUNG_12 = arrayOf("12", "3", "6", "9")
-
+class DefaultClockRenderer(private val picker: TimeRangePicker): BitmapCachedClockRenderer {
     private val _minuteTickWidth = 1.px
     private val _hourTickWidth = 2.px
-    private val _middle = PointF(0f, 0f)
+    private var _middle: Float = 0f
 
-    private val TimeRangePicker._tickLength
-        get() = when (clockFace) {
+    private var _bitmapCache: Bitmap? = null
+    private var _bitmapCacheCanvas: Canvas? = null
+
+    private var _isBitmapCacheEnabled = true
+    override var isBitmapCacheEnabled: Boolean
+        get() = _isBitmapCacheEnabled
+        set(value) {
+            val oldValue = _isBitmapCacheEnabled
+            _isBitmapCacheEnabled = value
+
+            if(oldValue != value) {
+                invalidateBitmapCache()
+            }
+        }
+
+    private val _tickLength
+        get() = when (picker.clockFace) {
             TimeRangePicker.ClockFace.APPLE -> 6.px
             TimeRangePicker.ClockFace.SAMSUNG -> 4.px
         }
 
-    private val TimeRangePicker._tickCount: Int
-        get() = when (clockFace) {
+    private val _tickCount: Int
+        get() = when (picker.clockFace) {
             TimeRangePicker.ClockFace.APPLE -> 48
             TimeRangePicker.ClockFace.SAMSUNG -> 120
         }
@@ -35,13 +46,83 @@ object DefaultClockRenderer: ClockRenderer {
         style = Paint.Style.STROKE
         strokeCap = Paint.Cap.ROUND
     }
+
     private val _labelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         textAlign = Paint.Align.CENTER
     }
 
-    override fun render(canvas: Canvas, picker: TimeRangePicker, radius: Float) {
-        _middle.x = canvas.width / 2f
-        _middle.y = canvas.width / 2f
+    override fun render(canvas: Canvas) {
+        if(isBitmapCacheEnabled) {
+            val radius = picker.clockRadius
+            val bitmap = _bitmapCache ?: throw RuntimeException("_bitmapCache == null")
+
+            val center = canvas.width / 2
+            val bitmapLeft = center - radius
+            val bitmapTop = center - radius
+
+            canvas.drawBitmap(bitmap, bitmapLeft, bitmapTop, null)
+        } else {
+            renderInternal(canvas)
+        }
+    }
+
+    override fun invalidateBitmapCache() {
+        if (isBitmapCacheEnabled) {
+            val size = picker.clockRadius.toInt() * 2
+
+            if(size > 0) {
+                val bitmap = _bitmapCache
+
+                if (bitmap == null) {
+                    resizeBitmapCacheThroughRecreating(size)
+                } else {
+                    val oldSize = bitmap.width
+                    // width & height are always the same, so there is no need to do extra check with height
+                    if (oldSize != size) {
+                        // reconfiguring works only when new size is smaller or equal to old
+                        if (Build.VERSION.SDK_INT >= 19 && size < oldSize) {
+                            resizeBitmapCacheThroughReconfiguring(size)
+                        } else {
+                            resizeBitmapCacheThroughRecreating(size)
+                        }
+                    }
+                }
+
+                val canvas =
+                    _bitmapCacheCanvas ?: throw RuntimeException("_bitmapCacheCanvas == null")
+                canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR)
+
+                renderInternal(canvas)
+            }
+        } else {
+            recycleBitmapCache()
+        }
+    }
+
+    override fun recycleBitmapCache() {
+        _bitmapCache?.recycle()
+        _bitmapCache = null
+        _bitmapCacheCanvas = null
+    }
+
+    private fun resizeBitmapCacheThroughRecreating(newSize: Int) {
+        // recycle old cache
+        _bitmapCache?.recycle()
+
+        val b = Bitmap.createBitmap(newSize, newSize, Bitmap.Config.ARGB_8888)
+        _bitmapCache = b
+        _bitmapCacheCanvas = Canvas(b)
+    }
+
+    @RequiresApi(19)
+    private fun resizeBitmapCacheThroughReconfiguring(newSize: Int) {
+        val bitmap = _bitmapCache ?: throw RuntimeException("_bitmapCache == null")
+        bitmap.reconfigure(newSize, newSize, Bitmap.Config.ARGB_8888)
+        _bitmapCacheCanvas = Canvas(bitmap)
+    }
+
+    private fun renderInternal(canvas: Canvas) {
+        _middle = (canvas.width / 2).toFloat()
 
         _tickPaint.color = picker.clockTickColor
         _labelPaint.apply {
@@ -49,14 +130,15 @@ object DefaultClockRenderer: ClockRenderer {
             color = picker.clockLabelColor
         }
 
-        drawTicks(canvas, picker, radius)
-        drawLabels(canvas, picker, radius)
+        drawTicks(canvas)
+        drawLabels(canvas)
     }
 
-    private fun drawTicks(canvas: Canvas, picker: TimeRangePicker, radius: Float) {
+    private fun drawTicks(canvas: Canvas) {
+        val radius = picker.clockRadius
         val hourTickInterval = if(picker.hourFormat == TimeRangePicker.HourFormat.FORMAT_24) 24 else 12
-        val tickLength = picker._tickLength
-        val tickCount = picker._tickCount
+        val tickLength = _tickLength
+        val tickCount = _tickCount
         val hourTick = tickCount / hourTickInterval
         val offset = if(picker.clockLabelSize.dp <= 16) 3 else 6
         val anglePerTick = 360f / tickCount
@@ -69,11 +151,11 @@ object DefaultClockRenderer: ClockRenderer {
             val sinAngle = sin(angleRadians).toFloat()
             val cosAngle = cos(angleRadians).toFloat()
 
-            val startX = _middle.x + radius * cosAngle
-            val startY = _middle.y + radius * sinAngle
+            val startX = _middle + radius * cosAngle
+            val startY = _middle + radius * sinAngle
 
-            val stopX = _middle.x + stopRadius * cosAngle
-            val stopY = _middle.y + stopRadius * sinAngle
+            val stopX = _middle + stopRadius * cosAngle
+            val stopY = _middle + stopRadius * sinAngle
 
             if (picker.clockFace == TimeRangePicker.ClockFace.SAMSUNG &&
                 ((angle >= 90-offset && angle <= 90+offset) ||
@@ -99,7 +181,7 @@ object DefaultClockRenderer: ClockRenderer {
     private val _drawLabelsBounds = Rect()
     private val _drawLabelsPosition = PointF()
 
-    private fun drawLabels(canvas: Canvas, picker: TimeRangePicker, radius: Float) {
+    private fun drawLabels(canvas: Canvas) {
         val labels = when (picker.clockFace) {
             TimeRangePicker.ClockFace.APPLE -> {
                 if (picker.hourFormat == TimeRangePicker.HourFormat.FORMAT_24) {
@@ -119,7 +201,8 @@ object DefaultClockRenderer: ClockRenderer {
 
         val bounds = _drawLabelsBounds
         val position = _drawLabelsPosition
-        val tickLength = picker._tickLength.toFloat()
+        val tickLength = _tickLength.toFloat()
+        val radius = picker.clockRadius
 
         for (i in labels.indices) {
             val label = labels[i]
@@ -143,7 +226,15 @@ object DefaultClockRenderer: ClockRenderer {
 
     private fun getPositionByAngle(radius: Float, angle: Float, outPoint: PointF) {
         val angleRadians = Math.toRadians(angle.toDouble())
-        outPoint.x = _middle.x + radius * cos(angleRadians).toFloat()
-        outPoint.y = _middle.y + radius * sin(angleRadians).toFloat()
+        outPoint.x = _middle + radius * cos(angleRadians).toFloat()
+        outPoint.y = _middle + radius * sin(angleRadians).toFloat()
+    }
+
+    companion object {
+        private val LABELS_APPLE_24 = arrayOf("0", "2", "4", "6", "8", "10", "12", "14", "16", "18", "20", "22")
+        private val LABELS_APPLE_12 =  arrayOf("12", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11")
+
+        private val LABELS_SAMSUNG_24 = arrayOf("0", "6", "12", "18")
+        private val LABELS_SAMSUNG_12 = arrayOf("12", "3", "6", "9")
     }
 }

--- a/timerangepicker/src/main/java/nl/joery/timerangepicker/utils/ReflectionUtils.kt
+++ b/timerangepicker/src/main/java/nl/joery/timerangepicker/utils/ReflectionUtils.kt
@@ -2,57 +2,24 @@ package nl.joery.timerangepicker.utils
 
 import nl.joery.timerangepicker.ClockRenderer
 import nl.joery.timerangepicker.TimeRangePicker
-import java.lang.reflect.Field
-import java.lang.reflect.Modifier
 
-private const val KSINGLETION_EXPECTED_MODS =
-    Modifier.PUBLIC or Modifier.STATIC or Modifier.FINAL
-
-internal fun createClockRenderer(name: String): ClockRenderer {
+internal fun createClockRenderer(name: String, picker: TimeRangePicker): ClockRenderer {
     val c = Class.forName(name, true, TimeRangePicker::class.java.classLoader)
 
     // try to find only public with no arguments
     for (constructor in c.constructors) {
-        if (constructor.parameterTypes.isEmpty()) {
-            val raw = constructor.newInstance()
-            val renderer: ClockRenderer
+        val params = constructor.parameterTypes
+
+        if(params.size == 1 && params[0] == TimeRangePicker::class.java) {
+            val raw = constructor.newInstance(picker)
+
             try {
-                renderer = raw as ClockRenderer
+                return raw as ClockRenderer
             } catch (e: ClassCastException) {
                 throw ClassCastException("Class '$name' is set as clock renderer but it does not extend '${TimeRangePicker::class.java.name}'")
             }
-
-            return renderer
         }
     }
 
-    // maybe it's singleton
-    val instanceField: Field
-    try {
-        instanceField = c.getField("INSTANCE")
-    } catch (e: NoSuchFieldException) {
-        throw RuntimeException("Clock renderer ($name) does not contain any public constructor with no parameters or INSTANCE field")
-    }
-
-    val mods = instanceField.modifiers
-    // check whether field modifiers contains only expected bits and any others
-    if ((mods and KSINGLETION_EXPECTED_MODS) != KSINGLETION_EXPECTED_MODS) {
-        // we checked whether class contains constructors with no parameters
-        // If there are no such constructors, programmer may expect that library picks value from INSTANCE field,
-        // which is typical for singletons.
-        // The field has invalid modifiers and we should inform that something is wrong
-        // with the field.
-        throw RuntimeException("Field INSTANCE has invalid modifiers (expected: public static final)")
-    }
-
-    val instanceRaw: Any = instanceField.get(null) ?: throw NullPointerException("Field INSTANCE in '$name' is null")
-
-    val renderer: ClockRenderer
-    try {
-        renderer = instanceRaw as ClockRenderer
-    } catch(e: ClassCastException) {
-        throw ClassCastException("Field INSTANCE in '$name' does not extend ${TimeRangePicker::class.java.name}")
-    }
-
-    return renderer
+    throw RuntimeException("Clock renderer ($name) does not contain any public constructor with one parameter: ${TimeRangePicker::class.java.name}")
 }


### PR DESCRIPTION
When a user drags thumbs, obviously, the entire view is re-drawn. When a user interacts with the picker, clock settings are not changed. So we can cache clock in a bitmap. With bitmap cache, much fewer computations happen. But re-sizing becomes much more expensive. 
If caching bitmap is not preferred, it can be disabled. 